### PR TITLE
Create models migrations

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,3 @@
+class Event < ActiveRecord::Base
+  belongs_to :group_rep
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,3 @@
+class Group < ActiveRecord::Base
+  belongs_to: neighborhood
+end

--- a/app/models/group_rep.rb
+++ b/app/models/group_rep.rb
@@ -1,0 +1,8 @@
+class GroupRep < ActiveRecord::Base
+  belongs_to :group_id
+  has_many :events, foreign_key: :group_rep_id
+  validates_format_of :email, :with => /@/
+
+  has_secure_password
+
+end

--- a/app/models/neighborhood.rb
+++ b/app/models/neighborhood.rb
@@ -1,0 +1,4 @@
+class Neighborhood < ActiveRecord::Base
+  has_many :groups, foreign_key: :neighborhood_id
+
+end

--- a/db/migrate/20160425170405_create_neighborhoods.rb
+++ b/db/migrate/20160425170405_create_neighborhoods.rb
@@ -1,0 +1,9 @@
+class CreateNeighborhoods < ActiveRecord::Migration
+  def change
+    create_table :neighborhoods do |t|
+      t.string :name
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160425171622_create_groups.rb
+++ b/db/migrate/20160425171622_create_groups.rb
@@ -1,7 +1,7 @@
 class CreateGroups < ActiveRecord::Migration
   def change
     create_table :groups do |t|
-      t.references :neighborhood
+      t.references :neighborhood, index: true, foreign_key: true
       t.string :name
       t.string :website
       t.string :contact_info

--- a/db/migrate/20160425171622_create_groups.rb
+++ b/db/migrate/20160425171622_create_groups.rb
@@ -1,0 +1,12 @@
+class CreateGroups < ActiveRecord::Migration
+  def change
+    create_table :groups do |t|
+      t.references :neighborhood
+      t.string :name
+      t.string :website
+      t.string :contact_info
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160425172332_create_group_reps.rb
+++ b/db/migrate/20160425172332_create_group_reps.rb
@@ -1,0 +1,13 @@
+class CreateGroupReps < ActiveRecord::Migration
+  def change
+    create_table :group_reps do |t|
+      t.references :group, index: true, foreign_key: true
+      t.string :name
+      t.string :email
+      t.string :string
+      t.string :password
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160425173154_create_events.rb
+++ b/db/migrate/20160425173154_create_events.rb
@@ -1,0 +1,13 @@
+class CreateEvents < ActiveRecord::Migration
+  def change
+    create_table :events do |t|
+      t.references :group_rep, index: true, foreign_key: true
+      t.string :name
+      t.string :organizer_contact_info
+      t.datetime :event_time
+      t.boolean :is_free, default: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  group_rep_id: 
+  name: MyString
+  organizer_contact_info: MyString
+  event_time: 2016-04-25 12:31:54
+  is_free: false
+
+two:
+  group_rep_id: 
+  name: MyString
+  organizer_contact_info: MyString
+  event_time: 2016-04-25 12:31:54
+  is_free: false

--- a/test/fixtures/group_reps.yml
+++ b/test/fixtures/group_reps.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  group_id_id: 
+  name: MyString
+  email: MyString
+  string: MyString
+  password: MyString
+
+two:
+  group_id_id: 
+  name: MyString
+  email: MyString
+  string: MyString
+  password: MyString

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  neighborhood_id: MyString
+  name: MyString
+  website: MyString
+  contact_info: MyString
+
+two:
+  neighborhood_id: MyString
+  name: MyString
+  website: MyString
+  contact_info: MyString

--- a/test/fixtures/neighborhoods.yml
+++ b/test/fixtures/neighborhoods.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  id: MyString
+  name: MyString
+
+two:
+  id: MyString
+  name: MyString

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/group_rep_test.rb
+++ b/test/models/group_rep_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupRepTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/neighborhood_test.rb
+++ b/test/models/neighborhood_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class NeighborhoodTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
I belatedly realized that the neighborhoods to groups one-to-many relationship in my schema should be a many to many relationship.  Neighborhoods overlap and users may disagree about what neighborhood a group is located in.  Also, many groups may serve more than one neighborhood, e.g. a Southwest economic development organization may serve Chicago Lawn, Gage Park, Marquette Park and more!  I will fix my schema and associations in the next work session.
